### PR TITLE
Reading #2

### DIFF
--- a/content/docs/end_users/catch-all-data-repository/catch-all-getting-started.mdx
+++ b/content/docs/end_users/catch-all-data-repository/catch-all-getting-started.mdx
@@ -11,7 +11,9 @@ Visit the [catch-all repository](https://datarepo.eosc.cz).
 
 An unauthenticated user can
 - search for keywords using the Search field
-- or browse all published records in the catch-all data repository by using **BROWSE ALL RECORDS**.
+- or browse all published records in the catch-all data repository by using **BROWSE ALL RECORDS**
+- data and metadata are provided with no guarantees; the repository and its operator 
+  assume no liability for any issues arising from their use
 
 ![new-record](/img/nrp/catch-all-data-repository/data-repo1.png)
 

--- a/content/docs/end_users/catch-all-data-repository/catch-all-repository-introduction.mdx
+++ b/content/docs/end_users/catch-all-data-repository/catch-all-repository-introduction.mdx
@@ -39,9 +39,12 @@ TL;DR what you need to know:
 
   - published data is publically accessible on the internet (without any user authentication)
 
-  - supported dataset licenses are variants of Creative Commons
+  - a set of standard Creative Commons licenses and their variants is available in the repository; 
+    specific licenses can be assigned by the submitters
 
-  - metadata is publicly available and completely free to use; it is harvested by the National Metadata Directory and other search services; note that, as metadata is not considered a work of authorship, its license is CC0
+  - metadata is made publicly available via the web user interface, the OAI-PMH protocol, and API in several standard formats: 
+    Dublin Core, DataCite, CCMM_FIXME; it is harvested by the National Metadata Directory (NMA) and other search services; 
+    metadata is not considered a work of authorship, therefore its license is CC0 and it is completely free to use
   
   - when using the publisdhed data, kindly follow the specified license
 
@@ -60,6 +63,12 @@ TL;DR what you need to know:
   - due to support of diverse file formats, no automatic format conversion is provided
   
   - binary consistency of data is regularly checked; data is stored in multiple geographic locations, and the repository frontends also run in multiple locations to ensure high availability
+
+  - retention period: minimum XX_FIXME years; in case of closure, every effort will be made by the repository operator to 
+    move the content to an alternative generic repository
+
+  - Catch-all Data Repository is part of the European Open Science Cloud (EOSC) enviroenment developed in the Czech Republic
+    for long-term research data retention
   
   - [user communities are supported](catch-all-getting-started)
 

--- a/content/docs/end_users/catch-all-data-repository/catch-all-repository-record-creation.mdx
+++ b/content/docs/end_users/catch-all-data-repository/catch-all-repository-record-creation.mdx
@@ -11,13 +11,19 @@ unless stated otherwise):
 - all users who are members of appropriate VO can create records
   (such users are called submitters); this requires registration in the AAI
   system
-- there can be fair use policy that
-  restricts submitters to create at most N records containing at most M bytes of
-  data in at most K files; they need to become members of a special group (handled by user
+- fair use policy is in place that restricts submitters to create at most 
+  N_FIXME records containing at most M_FIXME bytes of data in at most 
+  K_FIXME files; they need to become members of a special group (handled by user
   support) to get unlimited access
 - submitters can create a new record using CCMM metadata model and upload
   files to the record (number and size of files limited by applicable
   quotas)
+- by submitting data for publishing in the repository, the submitter and the 
+  repository operator conclude the following [Deposit Licence Agreement](FIXME) 
+- submitters retain full ownership of their content, no rights are transferred to 
+  the repository operator
+- submitters shall provide metadata to the fullest extent possible and make every effort 
+  to ensure its accuracy
 - metadata-only records are supported (i.e. records without files)
 - until publication, the record is visible only to the submitter
 - the submitter can create a “share link (preview only)”, i.e. an URL, a
@@ -27,8 +33,8 @@ unless stated otherwise):
 - the submitter can create a “share link with editing”, in addition, it
   allows the recipient of the link to edit the record with the same
   permissions as the submitter
-- after saving the record, compliance with the metadata model is checked
-  and errors reported
+- after clicking the “Save” button, the record is validated against the metadata schema, 
+  and any errors are displayed
 - the submitter can use “advanced check” functionality before submitting the record. In the advanced check, a LLM is triggered to check the metadata and act
   as a curator, providing recommendations for the submitter to improve
   quality of the metadata of the record. The LLM is operated on premise in
@@ -38,7 +44,7 @@ unless stated otherwise):
   records)
 - if a new version of a record with DOI is created, then the new version
   will get a DOI automatically
-- publishing: after clicking on publish, the record is published (i.e. will
+- publishing: after clicking the “Publish” button, the record is published (i.e. it will
   become publicly available for the whole internet)
 
 - (for future releases) grace period will be supported for published

--- a/content/docs/end_users/catch-all-data-repository/guide-for-communities.mdx
+++ b/content/docs/end_users/catch-all-data-repository/guide-for-communities.mdx
@@ -5,7 +5,7 @@ title: Guide for Communities
 ## Communities in the Catch-all Repository
 
 By obtaining deposition permissons to the repository, the user becomes a
-member of the “General community.”
+member of the “General community”.
 
 In special cases, it may make sense for a group of users to establish a
 dedicated community in the repository, e.g. when their own repository is
@@ -15,9 +15,8 @@ which setting up a full repository would be an overkill.
 
 ## Properties of the Community
 
-In general, the community in the Catch-all data repository will have the
-same metadata models and deposition process available as the rest of the
-repository.
+In general, all communities within the Catch-all Data Repository use the same 
+metadata profile and submission workflow.
 
 The community support following specific functions:
   - if desired, the community can be set up so that 


### PR DESCRIPTION
added a few unimportant details, suggested slight irrelevant factual (or—in minority of cases—style) modifications; if accepted, a single-file policy should be composed of thus created building blocks.

switching [content/docs/end_users/catch-all-data-repository/catch-all-repository-introduction.mdx[(https://github.com/NRP-CZ/documentation/blob/fumadocs/content/docs/end_users/catch-all-data-repository/catch-all-repository-introduction.mdx) back to LF (sorry for that); preserving LF in the remaining modified files.