### PR TITLE
Remove warning at compute page

### DIFF
--- a/content/docs/end_users/compute/support-for-computing.mdx
+++ b/content/docs/end_users/compute/support-for-computing.mdx
@@ -1,10 +1,6 @@
 ---
 title: Support for computing workflows
 ---
-<Callout type="warn" icon="⚠️">
-  This page is under construction.
-</Callout>
-
 ## Public pilot
 This is the landing page for the public pilot project connecting the NRP and e-INFRA.CZ computing environments. Please feel free to try out the solutions and components, and provide us with feedback. Thank you in advance.
 


### PR DESCRIPTION
No more changes received from KA5.4 team. Releasing the page as deliverable.