### PR TITLE
Document creator and contributor identifiers

### DIFF
--- a/content/docs/end_users/catch-all-data-repository/catch-all-repository-record-creation.mdx
+++ b/content/docs/end_users/catch-all-data-repository/catch-all-repository-record-creation.mdx
@@ -162,6 +162,46 @@ from the corresponding list.
 
 ![Required and optional record metadata](/img/nrp/catch-all-data-repository/record-required-metadata.png)
 
+#### Creator and Contributor Identifiers
+
+When adding a creator or contributor, you can also provide an identifier.
+
+ORCID identifiers are recognized automatically and can be entered without a
+prefix, for example:
+
+`0000-0002-1825-0097`
+
+All other identifiers must use the following format:
+
+`prefix:value`
+
+The `orcid:` prefix can also be used, although it is not required for ORCID
+identifiers.
+
+The supported prefixes are:
+
+- `orcid`
+- `isni`
+- `gnd`
+- `ror`
+- `scopusid`
+- `researcherid`
+- `czenasautid`
+- `vedidk`
+- `institutionalid`
+- `ico`
+- `doi`
+- `url`
+- `grid`
+
+For example:
+
+- `orcid:0000-0002-1825-0097`
+- `isni:0000000121032683`
+- `gnd:118529579`
+- `ror:01ggx4157`
+- `scopusid:12345678900`
+
 ### Funding
 
 Use the **Funding** section to add grants or other funding associated with the


### PR DESCRIPTION
## Summary

- document automatic recognition of ORCID identifiers
- describe the required `prefix:value` format for other identifiers
- list all supported identifier prefixes
- add identifier examples